### PR TITLE
RKE2 coscmetic changes

### DIFF
--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -72,16 +72,16 @@ downstream_kubernetes_version = "v1.22.11-rancher1-1"
 ####
 ####
 
-# Number of RKE downstream cluster droplets with ALL roles
+# Number of RKE2 downstream cluster droplets with ALL roles
 rke2_all_roles_nodes = "1"
 
-# Number of RKE downstream cluster droplets with ETCD roles only
+# Number of RKE2 downstream cluster droplets with ETCD roles only
 rke2_etcd_nodes = "0"
 
-# Number of RKE downstream cluster droplets with CP roles only
+# Number of RKE2 downstream cluster droplets with CP roles only
 rke2_cp_nodes = "0"
 
-# Number of RKE downstream cluster droplets with WORKER roles only
+# Number of RKE2 downstream cluster droplets with WORKER roles only
 rke2_worker_nodes = "0"
 
 # Set the RKE2 downstream cluster Kubernetes version

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -52,6 +52,7 @@ use_cluster_yaml = false
 
 ####
 ####
+#Downstream RKE cluster
 
 # Number of RKE downstream cluster droplets with ALL roles
 downstream_all_roles_nodes = "1"
@@ -71,6 +72,8 @@ downstream_kubernetes_version = "v1.22.11-rancher1-1"
 
 ####
 ####
+
+#Downstream RKE2 cluster
 
 # Number of RKE2 downstream cluster droplets with ALL roles
 rke2_all_roles_nodes = "1"


### PR DESCRIPTION
Typo in the final "RKE2" section. Comments refer to RKE, missing the "2".  Purely cosmetic.