### PR TITLE
Fix pagination on branches lookup for RKE slugs in slugs script

### DIFF
--- a/list-rancher-k8s-slugs.sh
+++ b/list-rancher-k8s-slugs.sh
@@ -42,9 +42,9 @@ function rancherSlugs {
 }
 
 function rkeSlugs {
-  branch="$(curl -sL 'https://api.github.com/repos/rancher/kontainer-driver-metadata/branches?per_page=100' | jq -r '.[].name' | grep 'release-')"
+  branch="$(curl -sL 'https://api.github.com/repos/rancher/kontainer-driver-metadata/branches?per_page=100' | jq -r '.[].name' | grep -E '^release-v')"
   
-  PS3="Choose a branch to use: "
+  PS3="Choose a Rancher branch to search in: "
   COLUMNS=20
   select v in ${branch} master Exit; do
   	case $v in

--- a/list-rancher-k8s-slugs.sh
+++ b/list-rancher-k8s-slugs.sh
@@ -42,7 +42,7 @@ function rancherSlugs {
 }
 
 function rkeSlugs {
-  branch="$(curl -sL https://api.github.com/repos/rancher/kontainer-driver-metadata/branches | jq -r '.[].name' | grep 'release-')"
+  branch="$(curl -sL 'https://api.github.com/repos/rancher/kontainer-driver-metadata/branches?per_page=100' | jq -r '.[].name' | grep 'release-')"
   
   PS3="Choose a branch to use: "
   COLUMNS=20


### PR DESCRIPTION
The current pagination on the list-rancher-k8s-slugs for RKE does not currently get enough results to be able to list the branches starting with 'release-'. 

This is a quick fix to be able to see the RKE slugs again by making the pagination display 100 results (there are currently 58 branches so this should cover this for a while, if not permanently).

Additional details on pagination: https://stackoverflow.com/a/58772297